### PR TITLE
fix undefined variable in google-analytics call

### DIFF
--- a/src/main/webapp/WEB-INF/templates/footer.vm
+++ b/src/main/webapp/WEB-INF/templates/footer.vm
@@ -11,7 +11,7 @@
         window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
         ga('create', '$unescaped', 'auto');
         ga('set', 'anonymizeIp', true);
-		ga('set', v.url);
+	ga('set','page',window.location.href);
 		ga('send', 'pageview');
         </script>
         <script async src='https://www.google-analytics.com/analytics.js'></script>


### PR DESCRIPTION
this line was throwing an error because the variable 'v' is undefined. If the intent is to set the 'page' field to the current url, this should work, or else you could just drop the line as this just might duplicate what is already set automatically by google.