### PR TITLE
Docker improvements, addresses #426

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ For further development and debugging help, see the [Development section](#Devel
 First, use docker-compose to create a blacklab-server. Then, to create this frontend run:
 
 ```
-docker-compose build
+DOCKER_BUILDKIT=1 docker-compose build
 docker-compose up 
 ```
-
+The config file `./docker/config/corpus-frontend.properties` is mounted inside the container. See next section for the configuration details.
 
 Configuration
 ====================

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
     build:
         context: .
         dockerfile: docker/Dockerfile
+    volumes:
+      - ./docker/config/corpus-frontend.properties:/etc/blacklab/corpus-frontend.properties
     ports:
       - "8081:8080" # 8080 will be used by blacklab-server
 


### PR DESCRIPTION
Mount the config file inside the container and reflect that in the `README.md`. Also add `BUILDKIT` instructions, otherwise building the container might not work on certain systems. Closes #426 