### PR TITLE
Fixes for parallel corpora with dependency trees.

### DIFF
--- a/src/frontend/src/pages/search/results/table/HitRowDetails.vue
+++ b/src/frontend/src/pages/search/results/table/HitRowDetails.vue
@@ -9,7 +9,7 @@
 					<span class="fa fa-exclamation-triangle"></span><br> <span style="white-space: pre;" v-html="error"></span>
 				</p>
 				<template v-else-if="snippet"> <!-- context is the larger surrounding context of the hit. We don't always have one (when rendering docs we only have the immediate hit) -->
-					<template v-if="hasRelations && !row.annotatedField.isParallel">
+					<template v-if="hasRelations">
 						<label v-if="sentenceAvailable">
 							<input type="checkbox" v-model="sentenceShown" class="show-sentence-checkbox" />
 							<Spinner v-if="sentenceRequest" inline style="margin-right: 0.5em"/>{{$t('results.table.showFullSentence')}}
@@ -101,9 +101,9 @@ export default Vue.component('HitRowDetails', IRow.extend({
 		DepTree,
 		Spinner
 	},
-	props: { 
+	props: {
 		// NOTE: also update the watcher on this prop if you change this name!
-		row: Object as () => HitRowData, 
+		row: Object as () => HitRowData,
 	},
 	data: () => ({
 		sentenceRequest: null as null|Promise<any>,

--- a/src/frontend/src/store/search/index.ts
+++ b/src/frontend/src/store/search/index.ts
@@ -114,17 +114,18 @@ const get = {
 			field: QueryModule.get.sourceField().id,
 			patt,
 			pattgapdata: (QueryModule.get.patternString() && QueryModule.getState().gap) ? QueryModule.getState().gap!.value || undefined : undefined,
-			
+
 			sample: (state.global.sampleMode === 'percentage' && state.global.sampleSize) ? state.global.sampleSize : undefined,
 			samplenum: (state.global.sampleMode === 'count' && state.global.sampleSize) ? state.global.sampleSize : undefined,
 			sampleseed: state.global.sampleSize != null ? state.global.sampleSeed! /* non-null precondition checked above */ : undefined,
-			
+
 			sort: activeView.sort != null ? activeView.sort : undefined,
 			group: activeView.groupBy.join(','),
 			viewgroup: activeView.viewGroup != null ? activeView.viewGroup : undefined,
 			context: state.global.context != null ? state.global.context : undefined,
 			adjusthits: true,
-			withspans: corpusCustomizations.search.pattern.shouldAddWithSpans(patt) ?? FilterModule.get.hasSpanFilters(),
+			withspans: corpusCustomizations.search.pattern.shouldAddWithSpans(patt) ??
+				(FilterModule.get.hasSpanFilters() || CorpusModule.get.hasRelations()),
 		};
 	}, 'blacklabParameters')
 };


### PR DESCRIPTION
Parallel corpora with dependency relations wouldn't show the "show sentence" check and the dependency tree.

Done:
- skip alignment relations for dependency trees (TODO: actually, we should select a specific relation class like "dep", in case we e.g. have dependency and constituency relations)
- show dependency tree component for parallel corpora too
- add withspans=true for any corpus with relations

(there have also been fixes in BL, see [here](https://github.com/instituutnederlandsetaal/BlackLab/commit/9207546b3dab69165d666c341c5773cd69f25424))