### PR TITLE
Help guide users to custom.js information.

### DIFF
--- a/docs/src/030_customizing_the_interface/04_search_form/01_simple_search.md
+++ b/docs/src/030_customizing_the_interface/04_search_form/01_simple_search.md
@@ -2,6 +2,8 @@
 
 ![Simple Search](simple_search.png)
 
+<!-- @include: ../_custom_js_tip.md -->
+
 
 ## Changing the searched field
 

--- a/docs/src/030_customizing_the_interface/04_search_form/02_extended_search.md
+++ b/docs/src/030_customizing_the_interface/04_search_form/02_extended_search.md
@@ -3,6 +3,8 @@
 Extended search lets you search multiple fields at once.
 By default every `annotation` in your corpus is shown here, but you can limit or organize the selection as you see fit.
 
+<!-- @include: ../_custom_js_tip.md -->
+
 
 ## Group annotations in tabs
 

--- a/docs/src/030_customizing_the_interface/04_search_form/03_advanced_search.md
+++ b/docs/src/030_customizing_the_interface/04_search_form/03_advanced_search.md
@@ -2,6 +2,8 @@
 
 ![advanced search](./advanced_search.png)
 
+<!-- @include: ../_custom_js_tip.md -->
+
 
 ## Hide the Advanced Search
 

--- a/docs/src/030_customizing_the_interface/04_search_form/04_expert_search.md
+++ b/docs/src/030_customizing_the_interface/04_search_form/04_expert_search.md
@@ -1,7 +1,7 @@
 # Expert search
 
-![expert search](expert_search.png)
-
 Expert search lets you enter a query manually, enabling the full power of BlackLab's [CQL](https://blacklab.ivdnt.org/guide/query-language/)
 
 Nothing can be configured here currently.
+
+![expert search](expert_search.png)

--- a/docs/src/030_customizing_the_interface/04_search_form/05_show_hide_fields.md
+++ b/docs/src/030_customizing_the_interface/04_search_form/05_show_hide_fields.md
@@ -4,6 +4,8 @@ We have a simple way to quickly show or hide widgets for Annotations & Metadata 
 
 This is just a shorthand method of configuring several parts of the UI. Individual features can also be configured one by one. Refer to the [source code](@github:/src/frontend/src/store/search/ui.ts) for the full details. All of this module's exports are exposed under `window.vuexModules.ui`.
 
+<!-- @include: ../_custom_js_tip.md -->
+
 --------
 
 First run (from the browser console) `printCustomJs()`.

--- a/docs/src/030_customizing_the_interface/04_search_form/06_filters.md
+++ b/docs/src/030_customizing_the_interface/04_search_form/06_filters.md
@@ -1,10 +1,12 @@
 # Filters
-
-![filters](filters.png)
  
 In `Extended`, `Advanced` and `Expert` search, Filters are shown.
 These represent Document Metadata, e.g. year of writing, title, author, etc. (depending on how you indexed your data).
 In BlackLab terms, these are `metadata` fields, see [the docs](https://blacklab.ivdnt.org/guide/how-to-configure-indexing.html#document-metadata).
+
+![filters](filters.png)
+
+<!-- @include: ../_custom_js_tip.md -->
 
 
 ## Organize filters in tabs

--- a/docs/src/030_customizing_the_interface/04_search_form/07_widgets.md
+++ b/docs/src/030_customizing_the_interface/04_search_form/07_widgets.md
@@ -2,6 +2,8 @@
 
 The search form contains many input fields for Filters/Metadata and Annotations, and you can customize what widget is shown for each field.
 
+<!-- @include: ../_custom_js_tip.md -->
+
 ## Overview
 
 Widget types can be set for:

--- a/docs/src/030_customizing_the_interface/04_search_form/08_explore.md
+++ b/docs/src/030_customizing_the_interface/04_search_form/08_explore.md
@@ -2,6 +2,8 @@
 
 <!-- @include: ../_table_based_layout_tip.md -->
 
+<!-- @include: ../_custom_js_tip.md -->
+
 
 ::: tabs
 === Documents

--- a/docs/src/030_customizing_the_interface/04_search_form/09_other.md
+++ b/docs/src/030_customizing_the_interface/04_search_form/09_other.md
@@ -1,5 +1,7 @@
 # Other helpers and utilities/workflow for customization
 
+<!-- @include: ../_custom_js_tip.md -->
+
 ## Move an annotation/metadata field to a different group after the fact
 
 Where fields are located in the UI is dependent on the [metadataFieldGroups](./filters.md#organize-filters-in-tabs) and [annotationGroups](./extended_search.md#group-annotations-in-tabs). 

--- a/docs/src/030_customizing_the_interface/05_results/01_hits.md
+++ b/docs/src/030_customizing_the_interface/05_results/01_hits.md
@@ -2,6 +2,8 @@
 
 <!-- @include: ../_table_based_layout_tip.md -->
 
+<!-- @include: ../_custom_js_tip.md -->
+
 ![hits table](hits_table.png)
 
 

--- a/docs/src/030_customizing_the_interface/05_results/02_docs.md
+++ b/docs/src/030_customizing_the_interface/05_results/02_docs.md
@@ -2,6 +2,8 @@
 
 <!-- @include: ../_table_based_layout_tip.md -->
 
+<!-- @include: ../_custom_js_tip.md -->
+
 ![docs table](docs_table.png)
 
 ## Document titles (`getDocumentSummary`)

--- a/docs/src/030_customizing_the_interface/05_results/02_grouping_sorting.md
+++ b/docs/src/030_customizing_the_interface/05_results/02_grouping_sorting.md
@@ -1,5 +1,7 @@
 # Sorting and Grouping
 
+<!-- @include: ../_custom_js_tip.md -->
+
 ## Options
 
 Set which annotations and metadata are available for sorting and grouping the results.

--- a/docs/src/030_customizing_the_interface/05_results/04_exports.md
+++ b/docs/src/030_customizing_the_interface/05_results/04_exports.md
@@ -1,6 +1,8 @@
 
 # Exports
 
+<!-- @include: ../_custom_js_tip.md -->
+
 ## Show / Hide 
 Show or hide the export button
 

--- a/docs/src/030_customizing_the_interface/06_document_view/05_statistics.md
+++ b/docs/src/030_customizing_the_interface/06_document_view/05_statistics.md
@@ -11,6 +11,8 @@ These functions are only available on the `/docs/` page, not the `/search/` page
 Make sure you check for availability, or add the `page="article"` attribute to your custom JS in `search.xml` to ensure it only runs on the `/docs/` page.
 :::
 
+<!-- @include: ../_custom_js_tip.md -->
+
 
 ## Custom Statistics Table
 

--- a/docs/src/030_customizing_the_interface/08_new_api.md
+++ b/docs/src/030_customizing_the_interface/08_new_api.md
@@ -4,6 +4,8 @@ title: 🧪 New Customization API
 
 # New Callback-based API (Experimental) 
 
+<!-- @include: _custom_js_tip.md -->
+
 As an experiment, we're trying out a different approach for some new customizations. In your `custom.js` file(s), you can now use code like the following:
 
 ```js

--- a/docs/src/030_customizing_the_interface/_custom_js_tip.md
+++ b/docs/src/030_customizing_the_interface/_custom_js_tip.md
@@ -1,3 +1,3 @@
 ::: tip
-JavaScript snippets on this page should go in a custom JS file. See [here](/customizing_the_interface/) and the tutorial [here](/tutorials/customize_a_corpus).
+JavaScript snippets on this page should go in a custom JS file. See [here](/customizing_the_interface/intro) and the tutorial [here](/tutorials/customize_a_corpus).
 :::

--- a/docs/src/030_customizing_the_interface/_custom_js_tip.md
+++ b/docs/src/030_customizing_the_interface/_custom_js_tip.md
@@ -1,0 +1,3 @@
+::: tip
+JavaScript snippets on this page should go in a custom JS file. See [here](/customizing_the_interface/) and the tutorial [here](/tutorials/customize_a_corpus).
+:::


### PR DESCRIPTION
Users reading about how to customize a specific feature may not yet know how to start customizing the interface at all. To help guide them to the relevant information, add a tip to pages with custom JS snippets.